### PR TITLE
event.timeStamp doesn't always work in Firefox due to bug

### DIFF
--- a/scrollspeedmonitor.js
+++ b/scrollspeedmonitor.js
@@ -9,7 +9,7 @@ var ScrollSpeedMonitor = (function()
         $(window).scroll(function(e)
         {
             var scrollTop = $(this).scrollTop();
-            didScroll(e.timeStamp, scrollTop);
+            didScroll(new Date().getTime(), scrollTop);
         });
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=238041

Getting current time will provide same functionality and will work in Firefox.